### PR TITLE
Get rid of Nat Gateway

### DIFF
--- a/infrastructure/lib/service-stack.ts
+++ b/infrastructure/lib/service-stack.ts
@@ -19,6 +19,12 @@ export class KafkaJSCanaryStack extends cdk.Stack {
 
     const vpc = new ec2.Vpc(this, 'AppVPC', {
       maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [{
+        name: 'Public',
+        subnetType: ec2.SubnetType.PUBLIC,
+        cidrMask: 22
+      }]
     });
 
     const cluster = new ecs.Cluster(this, 'AppCluster', {

--- a/infrastructure/lib/service.ts
+++ b/infrastructure/lib/service.ts
@@ -12,6 +12,7 @@ import {
 } from '@aws-cdk/aws-ecs';
 import { RetentionDays } from '@aws-cdk/aws-logs';
 import { PolicyStatement } from '@aws-cdk/aws-iam';
+import { SubnetType } from '@aws-cdk/aws-ec2';
 
 export interface KafkaJSCanaryAppFargateServiceProps {
   readonly serviceName?: string;
@@ -141,6 +142,10 @@ export class KafkaJSCanaryAppFargateService extends cdk.Construct {
       propagateTags: props.propagateTags,
       enableECSManagedTags: props.enableECSManagedTags,
       platformVersion: props.platformVersion,
+      vpcSubnets: {
+        subnetType: SubnetType.PUBLIC
+      },
+      assignPublicIp: true
     });
   }
 }


### PR DESCRIPTION
This reconfigures the VPC to only have a single public subnet rather
than a private and a public one, and moves the service into that public
subnet. This allows us to get rid of the NAT Gateway that otherwise accrues
cost for no real reason.

The service still needs to be in a public subnet in order to have internet
access (for the Confluent Cloud cluster). It's necessary to assign public
IP addresses to the instances in order to be able to pull from the Docker registry.

FYI @tulios @JaapRood 